### PR TITLE
Update release-plan workflows

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -3,8 +3,9 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
-    types: 
+    types:
       - labeled
 
 concurrency:
@@ -12,14 +13,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-plan:
+    name: "Check Release Plan"
+    runs-on: ubuntu-latest
+    outputs:
+      command: ${{ steps.check-release.outputs.command }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: 'master'
+      # This will only cause the `check-plan` job to have a "command" of `release`
+      # when the .release-plan.json file was changed on the last commit.
+      - id: check-release
+        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
+
   prepare_release_notes:
     name: Prepare Release Notes
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    needs: check-plan
     outputs:
       explanation: ${{ steps.explanation.outputs.text }}
+    # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
     # only run on labeled event if the PR has already been merged
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
 
     steps:
       - uses: actions/checkout@v4
@@ -30,19 +49,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      
+
       - uses: pnpm/action-setup@v2
         with:
           version: 8
       - run: pnpm install --frozen-lockfile
-      
+
       - name: "Generate Explanation and Prep Changelogs"
         id: explanation
         run: |
           set -x
-          
+
           pnpm release-plan prepare
-          
+
           echo 'text<<EOF' >> $GITHUB_OUTPUT
           jq .description .release-plan.json -r >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: 'main'
+          ref: 'master'
       # This will only cause the `check-plan` job to have a result of `success`
       # when the .release-plan.json file was changed on the last commit. This
       # plus the fact that this action only runs on main will be enough of a guard


### PR DESCRIPTION
I just ran `run npm init release-plan-setup --update` to get the latest copy of the release plan workflows: https://github.com/mansona/create-release-plan-setup/releases/tag/v1.2.0-create-release-plan-setup