### PR TITLE
drop support for node < 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ["12", "14", "16"]
+        node-version: ["16", "18", "20"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This is mostly to prompt a breaking change on our fork since our resync with upstream was breaking anyway 👍 